### PR TITLE
Add profit target stop trading

### DIFF
--- a/OrderBlockTradingRobot5.cs
+++ b/OrderBlockTradingRobot5.cs
@@ -106,6 +106,13 @@ namespace NinjaTrader.NinjaScript.Strategies
                 profitTargetReached = false;
                 lastTradeDate = DateTime.MinValue;
                 Print("*** STRATEGY INITIALIZED ***: Profit target reset. EnableProfitTarget=" + EnableProfitTarget + " ProfitTargetAmount=" + ProfitTargetAmount + " ResetProfitTargetDaily=" + ResetProfitTargetDaily);
+                
+                // Additional safety: if profit target is disabled, ensure the flag is false
+                if (!EnableProfitTarget)
+                {
+                    profitTargetReached = false;
+                    Print("*** PROFIT TARGET DISABLED ***: Ensuring profitTargetReached is FALSE");
+                }
             }
             else if (State == State.Realtime)
             {
@@ -149,6 +156,12 @@ namespace NinjaTrader.NinjaScript.Strategies
                 {
                     profitTargetReached = false;
                     Print("SMALL P&L RESET: Profit target flag reset to FALSE due to negligible P&L. Time: " + Time[0] + " DailyProfit: " + dailyProfit.ToString("F4") + " TotalPL: " + totalPL.ToString("F4"));
+                }
+                // Additional safety: if we have no current position and zero P&L, reset regardless of date
+                else if (Position.MarketPosition == MarketPosition.Flat && dailyProfit == 0 && totalPL == 0)
+                {
+                    profitTargetReached = false;
+                    Print("FLAT POSITION RESET: Profit target flag reset to FALSE due to flat position and zero P&L. Time: " + Time[0]);
                 }
             }
 


### PR DESCRIPTION
Add configurable profit target functionality to stop trading once a set profit is reached.

---
<a href="https://cursor.com/background-agent?bcId=bc-9566dd1e-c9ee-40c6-8bae-fc6fa14cfa02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9566dd1e-c9ee-40c6-8bae-fc6fa14cfa02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>